### PR TITLE
Added Initialization to litleRequest and batchRequest

### DIFF
--- a/LitleSdkForNet/LitleSdkForNet/LitleBatch.cs
+++ b/LitleSdkForNet/LitleSdkForNet/LitleBatch.cs
@@ -48,18 +48,7 @@ namespace Litle.Sdk
             config["requestDirectory"] = Properties.Settings.Default.requestDirectory;
             config["responseDirectory"] = Properties.Settings.Default.responseDirectory;
 
-            communication = new Communications();
-
-            authentication = new authentication();
-            authentication.user = config["username"];
-            authentication.password = config["password"];
-
-            requestDirectory = config["requestDirectory"] + "\\Requests\\";
-            responseDirectory = config["responseDirectory"] + "\\Responses\\";
-
-            litleXmlSerializer = new litleXmlSerializer();
-            litleTime = new litleTime();
-            litleFile = new litleFile();
+            initializeRequest();
         }
 
         /**
@@ -89,11 +78,24 @@ namespace Litle.Sdk
         public litleRequest(Dictionary<String, String> config)
         {
             this.config = config;
+
+            initializeRequest();
+        }
+
+        private void initializeRequest()
+        {
             communication = new Communications();
 
             authentication = new authentication();
             authentication.user = config["username"];
             authentication.password = config["password"];
+
+            requestDirectory = config["requestDirectory"] + "\\Requests\\";
+            responseDirectory = config["responseDirectory"] + "\\Responses\\";
+
+            litleXmlSerializer = new litleXmlSerializer();
+            litleTime = new litleTime();
+            litleFile = new litleFile();
         }
 
         public void setCommunication(Communications communication)

--- a/LitleSdkForNet/LitleSdkForNet/LitleBatchRequest.cs
+++ b/LitleSdkForNet/LitleSdkForNet/LitleBatchRequest.cs
@@ -68,6 +68,18 @@ namespace Litle.Sdk
             config["requestDirectory"] = Properties.Settings.Default.requestDirectory;
             config["responseDirectory"] = Properties.Settings.Default.responseDirectory;
 
+            initializeRequest();
+        }
+
+        public batchRequest(Dictionary<String, String> config)
+        {
+            this.config = config;
+
+            initializeRequest();
+        }
+
+        private void initializeRequest()
+        {
             requestDirectory = config["requestDirectory"] + "\\Requests\\";
             responseDirectory = config["responseDirectory"] + "\\Responses\\";
 
@@ -98,11 +110,6 @@ namespace Litle.Sdk
             sumOfEcheckCredit = 0;
             sumOfEcheckVerification = 0;
             sumOfCaptureGivenAuth = 0;
-        }
-
-        public batchRequest(Dictionary<String, String> config)
-        {
-            this.config = config;
         }
 
         public void setLitleFile(litleFile litleFile)


### PR DESCRIPTION
litleRequest and batchRequest objects were not fully initialized when the override constructor was used (i.e. when a configuration dictionary was injected). I created private initialization methods in both objects and had both constructors in each object call the new method.
