### PR TITLE
Use application scope settings

### DIFF
--- a/LitleSdkForNet/LitleSdkForNet/Properties/Settings.Designer.cs
+++ b/LitleSdkForNet/LitleSdkForNet/Properties/Settings.Designer.cs
@@ -23,207 +23,156 @@ namespace Litle.Sdk.Properties {
             }
         }
         
-        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("https://www.testlitle.com/sandbox/communicator/online")]
         public string url {
             get {
                 return ((string)(this["url"]));
             }
-            set {
-                this["url"] = value;
-            }
         }
         
-        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("Default Report Group")]
         public string reportGroup {
             get {
                 return ((string)(this["reportGroup"]));
             }
-            set {
-                this["reportGroup"] = value;
-            }
         }
         
-        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("dotnet")]
         public string username {
             get {
                 return ((string)(this["username"]));
             }
-            set {
-                this["username"] = value;
-            }
         }
         
-        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("dotnet")]
         public string password {
             get {
                 return ((string)(this["password"]));
             }
-            set {
-                this["password"] = value;
-            }
         }
         
-        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("false")]
         public string printxml {
             get {
                 return ((string)(this["printxml"]));
             }
-            set {
-                this["printxml"] = value;
-            }
         }
         
-        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("65")]
         public string timeout {
             get {
                 return ((string)(this["timeout"]));
             }
-            set {
-                this["timeout"] = value;
-            }
         }
         
-        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
         public string proxyHost {
             get {
                 return ((string)(this["proxyHost"]));
             }
-            set {
-                this["proxyHost"] = value;
-            }
         }
         
-        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
         public string proxyPort {
             get {
                 return ((string)(this["proxyPort"]));
             }
-            set {
-                this["proxyPort"] = value;
-            }
         }
         
-        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("101")]
         public string merchantId {
             get {
                 return ((string)(this["merchantId"]));
             }
-            set {
-                this["merchantId"] = value;
-            }
         }
         
-        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("cert.litle.com")]
         public string sftpUrl {
             get {
                 return ((string)(this["sftpUrl"]));
             }
-            set {
-                this["sftpUrl"] = value;
-            }
         }
         
-        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("C:\\Litle\\dll\\knownhosts")]
         public string knownHostsFile {
             get {
                 return ((string)(this["knownHostsFile"]));
             }
-            set {
-                this["knownHostsFile"] = value;
-            }
         }
         
-        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("dotnet")]
         public string sftpUsername {
             get {
                 return ((string)(this["sftpUsername"]));
             }
-            set {
-                this["sftpUsername"] = value;
-            }
         }
         
-        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("dotnet")]
         public string sftpPassword {
             get {
                 return ((string)(this["sftpPassword"]));
             }
-            set {
-                this["sftpPassword"] = value;
-            }
         }
         
-        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("cert.litle.com")]
         public string onlineBatchUrl {
             get {
                 return ((string)(this["onlineBatchUrl"]));
             }
-            set {
-                this["onlineBatchUrl"] = value;
-            }
         }
         
-        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("15000")]
         public string onlineBatchPort {
             get {
                 return ((string)(this["onlineBatchPort"]));
             }
-            set {
-                this["onlineBatchPort"] = value;
-            }
         }
         
-        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("C:\\Litle\\")]
         public string requestDirectory {
             get {
                 return ((string)(this["requestDirectory"]));
             }
-            set {
-                this["requestDirectory"] = value;
-            }
         }
         
-        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("C:\\Litle\\")]
         public string responseDirectory {
             get {
                 return ((string)(this["responseDirectory"]));
-            }
-            set {
-                this["responseDirectory"] = value;
             }
         }
     }

--- a/LitleSdkForNet/LitleSdkForNet/Properties/Settings.settings
+++ b/LitleSdkForNet/LitleSdkForNet/Properties/Settings.settings
@@ -2,55 +2,55 @@
 <SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="Litle.Sdk.Properties" GeneratedClassName="Settings">
   <Profiles />
   <Settings>
-    <Setting Name="url" Type="System.String" Scope="User">
+    <Setting Name="url" Type="System.String" Scope="Application">
       <Value Profile="(Default)">https://www.testlitle.com/sandbox/communicator/online</Value>
     </Setting>
-    <Setting Name="reportGroup" Type="System.String" Scope="User">
+    <Setting Name="reportGroup" Type="System.String" Scope="Application">
       <Value Profile="(Default)">Default Report Group</Value>
     </Setting>
-    <Setting Name="username" Type="System.String" Scope="User">
+    <Setting Name="username" Type="System.String" Scope="Application">
       <Value Profile="(Default)">dotnet</Value>
     </Setting>
-    <Setting Name="password" Type="System.String" Scope="User">
+    <Setting Name="password" Type="System.String" Scope="Application">
       <Value Profile="(Default)">dotnet</Value>
     </Setting>
-    <Setting Name="printxml" Type="System.String" Scope="User">
+    <Setting Name="printxml" Type="System.String" Scope="Application">
       <Value Profile="(Default)">false</Value>
     </Setting>
-    <Setting Name="timeout" Type="System.String" Scope="User">
+    <Setting Name="timeout" Type="System.String" Scope="Application">
       <Value Profile="(Default)">65</Value>
     </Setting>
-    <Setting Name="proxyHost" Type="System.String" Scope="User">
+    <Setting Name="proxyHost" Type="System.String" Scope="Application">
       <Value Profile="(Default)" />
     </Setting>
-    <Setting Name="proxyPort" Type="System.String" Scope="User">
+    <Setting Name="proxyPort" Type="System.String" Scope="Application">
       <Value Profile="(Default)" />
     </Setting>
-    <Setting Name="merchantId" Type="System.String" Scope="User">
+    <Setting Name="merchantId" Type="System.String" Scope="Application">
       <Value Profile="(Default)">101</Value>
     </Setting>
-    <Setting Name="sftpUrl" Type="System.String" Scope="User">
+    <Setting Name="sftpUrl" Type="System.String" Scope="Application">
       <Value Profile="(Default)">cert.litle.com</Value>
     </Setting>
-    <Setting Name="knownHostsFile" Type="System.String" Scope="User">
+    <Setting Name="knownHostsFile" Type="System.String" Scope="Application">
       <Value Profile="(Default)">C:\Litle\dll\knownhosts</Value>
     </Setting>
-    <Setting Name="sftpUsername" Type="System.String" Scope="User">
+    <Setting Name="sftpUsername" Type="System.String" Scope="Application">
       <Value Profile="(Default)">dotnet</Value>
     </Setting>
-    <Setting Name="sftpPassword" Type="System.String" Scope="User">
+    <Setting Name="sftpPassword" Type="System.String" Scope="Application">
       <Value Profile="(Default)">dotnet</Value>
     </Setting>
-    <Setting Name="onlineBatchUrl" Type="System.String" Scope="User">
+    <Setting Name="onlineBatchUrl" Type="System.String" Scope="Application">
       <Value Profile="(Default)">cert.litle.com</Value>
     </Setting>
-    <Setting Name="onlineBatchPort" Type="System.String" Scope="User">
+    <Setting Name="onlineBatchPort" Type="System.String" Scope="Application">
       <Value Profile="(Default)">15000</Value>
     </Setting>
-    <Setting Name="requestDirectory" Type="System.String" Scope="User">
+    <Setting Name="requestDirectory" Type="System.String" Scope="Application">
       <Value Profile="(Default)">C:\Litle\</Value>
     </Setting>
-    <Setting Name="responseDirectory" Type="System.String" Scope="User">
+    <Setting Name="responseDirectory" Type="System.String" Scope="Application">
       <Value Profile="(Default)">C:\Litle\</Value>
     </Setting>
   </Settings>

--- a/LitleSdkForNet/LitleSdkForNet/app.config
+++ b/LitleSdkForNet/LitleSdkForNet/app.config
@@ -1,12 +1,14 @@
 <?xml version="1.0"?>
 <configuration>
   <configSections>
+    <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+      <section name="Litle.Sdk.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
+    </sectionGroup>
     <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <section name="Litle.Sdk.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false"/>
       <section name="LitleSdkForNet.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false"/>
     </sectionGroup>
   </configSections>
-  <userSettings>
+  <applicationSettings>
     <Litle.Sdk.Properties.Settings>
       <setting name="url" serializeAs="String">
         <value>https://www.testlitle.com/sandbox/communicator/online</value>
@@ -60,6 +62,8 @@
         <value>C:\Litle\</value>
       </setting>
     </Litle.Sdk.Properties.Settings>
+  </applicationSettings>
+  <userSettings>
     <LitleSdkForNet.Properties.Settings>
       <setting name="url" serializeAs="String">
         <value>https://www.testlitle.com/sandbox/communicator/online</value>


### PR DESCRIPTION
Replace the user scope settings with application scoped settings to support ASP.NET Web Services. User scope settings are not supported in ASP.NET and will throw [ConfigurationErrorsException: The current configuration system does not support user-scoped settings] if the SDK is used in a web service. This change is not backwards compatible.
