### PR TITLE
Add test case for invalid XML

### DIFF
--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestAuth.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestAuth.cs
@@ -123,6 +123,32 @@ namespace Litle.Sdk.Test.Functional
             authorizationResponse response = litle.Authorize(authorization);
             Assert.AreEqual("Approved", response.message);
         }
+
+        [Test]
+        public void AuthWithAmpersand()
+        {
+            authorization authorization = new authorization();
+            authorization.orderId = "1";
+            authorization.amount = 10010;
+            authorization.orderSource = orderSourceType.ecommerce;
+            contact contact = new contact();
+            contact.name = "John & Jane Smith";
+            contact.addressLine1 = "1 Main St.";
+            contact.city = "Burlington";
+            contact.state = "MA";
+            contact.zip = "01803-3747";
+            contact.country = countryTypeEnum.US;
+            authorization.billToAddress = contact;
+            cardType card = new cardType();
+            card.type = methodOfPaymentTypeEnum.VI;
+            card.number = "4457010000000009";
+            card.expDate = "0112";
+            card.cardValidationNum = "349";
+            authorization.card = card;
+
+            authorizationResponse response = litle.Authorize(authorization);
+            Assert.AreEqual("000", response.response);
+        }
             
     }
 }


### PR DESCRIPTION
The Serialize() methods in XmlRequestFields simply concatenate strings to generate the XML request. Since none of the input is escaped this will cause the XML to be invalid or malformed if the input contains reserved characters (i.e. greater than, less than, ampersand, and percent).

This commit adds a failing test case for input containing an ampersand. The test causes the Litle service to return "Error validating xml data against the schema The entity name must immediately follow the '&' in the entity reference."

One way to fix this issue is to use the XmlSerializer class which generates well-formed XML - as in the unused LitleOnline.SerializeObject() method. However, this will require some refactoring of the existing code. Another approach is to escape all input in the Serialize() methods.
