### PR TITLE
Add header/footer generation methods

### DIFF
--- a/LitleSdkForNet/LitleSdkForNet/LitleBatch.cs
+++ b/LitleSdkForNet/LitleSdkForNet/LitleBatch.cs
@@ -236,11 +236,8 @@ namespace Litle.Sdk
 
         public string Serialize()
         {
-            string xmlHeader = "<?xml version='1.0' encoding='utf-8'?>\r\n<litleRequest version=\"9.10\"" +
-             " xmlns=\"http://www.litle.com/schema\" " +
-             "numBatchRequests=\"" + numOfLitleBatchRequest + "\">";
-
-            string xmlFooter = "\r\n</litleRequest>";
+            string xmlHeader = generateXmlHeader();
+            string xmlFooter = generateXmlFooter();
 
             string filePath;
 
@@ -264,6 +261,22 @@ namespace Litle.Sdk
             finalFilePath = null;
 
             return filePath;
+        }
+
+        public string generateXmlHeader()
+        {
+            string xmlHeader = "<?xml version='1.0' encoding='utf-8'?>\r\n<litleRequest version=\"9.10\"" +
+             " xmlns=\"http://www.litle.com/schema\" " +
+             "numBatchRequests=\"" + numOfLitleBatchRequest + "\">";
+
+            return xmlHeader;
+        }
+
+        public string generateXmlFooter()
+        {
+            const string xmlFooter = "\r\n</litleRequest>";
+
+            return xmlFooter;
         }
 
         private void fillInReportGroup(batchRequest litleBatchRequest)

--- a/LitleSdkForNet/LitleSdkForNet/LitleBatchRequest.cs
+++ b/LitleSdkForNet/LitleSdkForNet/LitleBatchRequest.cs
@@ -998,8 +998,7 @@ namespace Litle.Sdk
         public string Serialize()
         {
             var xmlHeader = generateXmlHeader();
-
-            const string xmlFooter = "</batchRequest>\r\n";
+            var xmlFooter = generateXmlFooter();
 
             batchFilePath = litleFile.createRandomFile(requestDirectory, null, "_batchRequest.xml", litleTime);
 
@@ -1235,6 +1234,13 @@ namespace Litle.Sdk
 
             xmlHeader += "merchantId=\"" + config["merchantId"] + "\">\r\n";
             return xmlHeader;
+        }
+
+        public string generateXmlFooter()
+        {
+            const string xmlFooter = "</batchRequest>\r\n";
+
+            return xmlFooter;
         }
 
         private string saveElement(litleFile litleFile, litleTime litleTime, string filePath, transactionRequest element)


### PR DESCRIPTION
- Added generateXmlHeader and generateXmlFooter to the litleRequest and batchRequest objects.

For consumers of the SDK that are doing their own serialization of the objects, this helps encapsulate the XML schema, but yet provide the XML element boundaries.

There was currently a generateXmlHeader method on the batchRequest object. I added the same sort of method to the litleRequest object, and added "generateXmlFooter" methods to each respective object, so that the caller can fully serialize the objects and data, without needed to know the exact schema.