### PR TITLE
Adding `using` statement for StreamWriter

### DIFF
--- a/LitleSdkForNet/LitleSdkForNet/Communications.cs
+++ b/LitleSdkForNet/LitleSdkForNet/Communications.cs
@@ -53,11 +53,13 @@ namespace Litle.Sdk
                 {
                     NeuterXml(ref logMessage);
                 }
-                var logWriter = new StreamWriter(logFile, true);
-                var time = DateTime.Now;
-                logWriter.WriteLine(time.ToString(CultureInfo.InvariantCulture));
-                logWriter.WriteLine(logMessage + "\r\n");
-                logWriter.Close();
+
+                using (var logWriter = new StreamWriter(logFile, true))
+                {
+                    var time = DateTime.Now;
+                    logWriter.WriteLine(time.ToString(CultureInfo.InvariantCulture));
+                    logWriter.WriteLine(logMessage + "\r\n");
+                }
             }
         }
 


### PR DESCRIPTION
This ensures that if an exception happens while trying to log to the file, the client can call Dispose.

Could you take a look @brianarnold789 ?

Here is the error we saw in our logs:

```
System.IO.IOException: The process cannot access the file 'VantivLog.txt' because it is being used by another process.
    at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
    at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
    at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
    at System.IO.StreamWriter..ctor(String path, Boolean append, Encoding encoding, Int32 bufferSize, Boolean checkHost)
    at System.IO.StreamWriter..ctor(String path, Boolean append, Encoding encoding, Int32 bufferSize)
    at System.IO.StreamWriter..ctor(String path, Boolean append)
    at Litle.Sdk.Communications.log(String logMessage, String logFile, Boolean neuter)
    at Litle.Sdk.Communications.HttpPost(String xmlRequest, Dictionary`2 config)
    at Litle.Sdk.LitleOnline.sendToLitle(litleOnlineRequest request)
    at Litle.Sdk.LitleOnline.RegisterToken(registerTokenRequestType tokenRequest)
```