### PR TITLE
Add an HttpAction event to help with logging request and responses.

### DIFF
--- a/LitleSdkForNet/LitleSdkForNet/Communications.cs
+++ b/LitleSdkForNet/LitleSdkForNet/Communications.cs
@@ -13,10 +13,19 @@ using System.Text.RegularExpressions;
 
 namespace Litle.Sdk
 {
+
     public class Communications
     {
         private static readonly object SynLock = new object();
-
+        public event EventHandler HttpAction;
+        
+        private void OnHttpAction(RequestType requestType, string xmlPayload)
+        {
+            if (HttpAction != null)
+            {
+                HttpAction(this, new HttpActionEventArgs(requestType, xmlPayload));
+            }
+        }
 
         public static bool ValidateServerCertificate(
              object sender,
@@ -115,6 +124,8 @@ namespace Litle.Sdk
                 req.Proxy = myproxy;
             }
 
+            OnHttpAction(RequestType.Request, xmlRequest);
+
             // submit http request
             using (var writer = new StreamWriter(req.GetRequestStream()))
             {
@@ -132,6 +143,8 @@ namespace Litle.Sdk
             {
                 Console.WriteLine(xmlResponse);
             }
+
+            OnHttpAction(RequestType.Response, xmlResponse);
 
             //log response
             if (logFile != null)
@@ -450,4 +463,22 @@ namespace Litle.Sdk
             public string IdentityFile;
         }
     }
+
+    public enum RequestType
+    {
+        Request, Response
+    }
+
+    public class HttpActionEventArgs : EventArgs
+    {
+        public RequestType RequestType { get; set; }
+        public string XmlPayload;
+
+        public HttpActionEventArgs(RequestType requestType, string xmlPayload)
+        {
+            RequestType = requestType;
+            XmlPayload = xmlPayload;
+        }
+    }
+
 }

--- a/LitleSdkForNet/LitleSdkForNet/Communications.cs
+++ b/LitleSdkForNet/LitleSdkForNet/Communications.cs
@@ -19,10 +19,15 @@ namespace Litle.Sdk
         private static readonly object SynLock = new object();
         public event EventHandler HttpAction;
         
-        private void OnHttpAction(RequestType requestType, string xmlPayload)
+        private void OnHttpAction(RequestType requestType, string xmlPayload, bool neuter)
         {
             if (HttpAction != null)
             {
+                if (neuter)
+                {
+                    NeuterXml(ref xmlPayload);
+                }
+
                 HttpAction(this, new HttpActionEventArgs(requestType, xmlPayload));
             }
         }
@@ -95,11 +100,14 @@ namespace Litle.Sdk
             var printxml = false;
             if (config.ContainsKey("printxml"))
             {
-                if("true".Equals(config["printxml"])) {
+                if("true".Equals(config["printxml"])) 
+                {
                     printxml = true;
                 }
             }
-            if(printxml) {
+
+            if (printxml) 
+            {
                 Console.WriteLine(xmlRequest);
                 Console.WriteLine(logFile);
             }
@@ -107,7 +115,7 @@ namespace Litle.Sdk
             //log request
             if (logFile != null)
             {
-                Log(xmlRequest,logFile, neuter);
+                Log(xmlRequest, logFile, neuter);
             }
 
             req.ContentType = "text/xml; charset=UTF-8";
@@ -124,7 +132,7 @@ namespace Litle.Sdk
                 req.Proxy = myproxy;
             }
 
-            OnHttpAction(RequestType.Request, xmlRequest);
+            OnHttpAction(RequestType.Request, xmlRequest, neuter);
 
             // submit http request
             using (var writer = new StreamWriter(req.GetRequestStream()))
@@ -144,12 +152,12 @@ namespace Litle.Sdk
                 Console.WriteLine(xmlResponse);
             }
 
-            OnHttpAction(RequestType.Response, xmlResponse);
+            OnHttpAction(RequestType.Response, xmlResponse, neuter);
 
             //log response
             if (logFile != null)
             {
-                Log(xmlResponse,logFile,neuter);
+                Log(xmlResponse, logFile, neuter);
             }
 
             return xmlResponse;

--- a/LitleSdkForNet/LitleSdkForNet/LitleOnline.cs
+++ b/LitleSdkForNet/LitleSdkForNet/LitleOnline.cs
@@ -54,6 +54,12 @@ namespace Litle.Sdk
             communication = new Communications();
         }
 
+        public event EventHandler HttpAction
+        {
+            add { communication.HttpAction += value; }
+            remove { communication.HttpAction -= value; }
+        }
+
         public void setCommunication(Communications communication)
         {
             this.communication = communication;

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestHttpActionEvent.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestHttpActionEvent.cs
@@ -50,13 +50,21 @@ namespace Litle.Sdk.Test.Functional
                 }
             };
 
-            var capture = new capture
+            var forcecapture = new forceCapture
             {
-                litleTxnId = 123456000,
-                amount = 106
+                amount = 106,
+                orderId = "12344",
+                orderSource = orderSourceType.ecommerce,
+                card = new cardType
+                {
+                    type = methodOfPaymentTypeEnum.VI,
+                    number = "4100000000000001",
+                    expDate = "1210"
+                }
             };
 
-            _litle.Capture(capture);
+            _litle.ForceCapture(forcecapture);
+
             Assert.AreEqual(httpActionCount, 2);
             Assert.AreEqual(requestCount, 1);
             Assert.AreEqual(responseCount, 1);

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestHttpActionEvent.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestHttpActionEvent.cs
@@ -1,0 +1,65 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Litle.Sdk.Test.Functional
+{
+    [TestFixture]
+    internal class TestHttpActionEvent
+    {
+        private LitleOnline _litle;
+
+        [TestFixtureSetUp]
+        public void SetUpLitle()
+        {
+            var config = new Dictionary<string, string>
+            {
+                {"url", "https://www.testlitle.com/sandbox/communicator/online"},
+                {"reportGroup", "Default Report Group"},
+                {"username", "DOTNET"},
+                {"version", "8.13"},
+                {"timeout", "5000"},
+                {"merchantId", "101"},
+                {"password", "TESTCASE"},
+                {"printxml", "true"},
+                {"proxyHost", Properties.Settings.Default.proxyHost},
+                {"proxyPort", Properties.Settings.Default.proxyPort},
+                {"logFile", Properties.Settings.Default.logFile},
+                {"neuterAccountNums", "true"}
+            };
+            _litle = new LitleOnline(config);
+        }
+
+        [Test]
+        public void TestHttpEvents()
+        {
+            int requestCount = 0;
+            int responseCount = 0;
+            int httpActionCount = 0;
+
+            _litle.HttpAction += (sender, args) =>
+            {
+                var eventArgs = (HttpActionEventArgs)args;
+                httpActionCount++;
+                if (eventArgs.RequestType == RequestType.Request)
+                {
+                    requestCount++;
+                }
+                else if (eventArgs.RequestType == RequestType.Response)
+                {
+                    responseCount++;
+                }
+            };
+
+            var capture = new capture
+            {
+                litleTxnId = 123456000,
+                amount = 106
+            };
+
+            _litle.Capture(capture);
+            Assert.AreEqual(httpActionCount, 2);
+            Assert.AreEqual(requestCount, 1);
+            Assert.AreEqual(responseCount, 1);
+        }
+    }
+}

--- a/LitleSdkForNet/LitleSdkForNetTest/LitleSdkForNetTest.csproj
+++ b/LitleSdkForNet/LitleSdkForNetTest/LitleSdkForNetTest.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Certification\TestCert4Echeck.cs" />
     <Compile Include="Certification\TestCert5Token.cs" />
     <Compile Include="Certification\TestCert1Base.cs" />
+    <Compile Include="Functional\TestHttpActionEvent.cs" />
     <Compile Include="Functional\TestUTF8.cs" />
     <Compile Include="Functional\TestBatchStream.cs" />
     <Compile Include="Functional\TestBatch.cs" />


### PR DESCRIPTION
Raising an event when we send and receive XML to facilitate more diverse logging options.