### PR TITLE
add the HttpAction event to the ILitleOnline interface

### DIFF
--- a/LitleSdkForNet/LitleSdkForNet/LitleOnline.cs
+++ b/LitleSdkForNet/LitleSdkForNet/LitleOnline.cs
@@ -679,5 +679,6 @@ namespace Litle.Sdk
 		Task<transactionTypeWithReportGroup> queryTransactionAsync(queryTransaction queryTransaction, CancellationToken cancellation);
 		updateCardValidationNumOnTokenResponse UpdateCardValidationNumOnToken(updateCardValidationNumOnToken update);
 		Task<updateCardValidationNumOnTokenResponse> UpdateCardValidationNumOnTokenAsync(updateCardValidationNumOnToken update, CancellationToken cancellationToken);
+	    event EventHandler HttpAction;
 	}
 }


### PR DESCRIPTION
The `HTTPAction` event is directly on the class, not the `ILitleOnline` interface so programming to the interface is difficult.  This adds it to the interface for easier mocking.