### PR TITLE
Functional tests fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 = LitleOnline CHANGELOG
 
+== Version 11.4.91 (February 14, 2020)
+* BugFix: Fix functional tests that were failing after change in sandbox
+
 == Version 11.4.9 (October 25, 2019)
 * BugFix: Fixed timeout not being used in non-async methods
 

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestPayFac.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestPayFac.cs
@@ -40,7 +40,7 @@ namespace Litle.Sdk.Test.Functional
                 id = "1",
                 reportGroup = "Default Report Group",
                 // required child elements.
-                amount = 1500,
+                amount = 15121,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId"
             };
@@ -58,7 +58,7 @@ namespace Litle.Sdk.Test.Functional
                 id = "1",
                 reportGroup = "Planets",
                 // required child elements.
-                amount = 1500,
+                amount = 15121,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId"
             };

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestPayFac.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestPayFac.cs
@@ -40,7 +40,7 @@ namespace Litle.Sdk.Test.Functional
                 id = "1",
                 reportGroup = "Default Report Group",
                 // required child elements.
-                amount = 15121,
+                amount = 1000,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId"
             };

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestPayFac.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestPayFac.cs
@@ -58,7 +58,7 @@ namespace Litle.Sdk.Test.Functional
                 id = "1",
                 reportGroup = "Planets",
                 // required child elements.
-                amount = 15121,
+                amount = 1000,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId"
             };

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestPgpBatchRequest.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestPgpBatchRequest.cs
@@ -19,7 +19,7 @@ namespace Litle.Sdk.Test.Functional
         public void SetUp()
         {
             var pgpEnabled = Environment.GetEnvironmentVariable("pgpFunctionalTestsEnabled");
-            if(pgpEnabled != null && pgpEnabled.ToLower.Equals("false"))
+            if(pgpEnabled != null && pgpEnabled.ToLower().Equals("false"))
             {
                 Assert.Ignore("PGP functional tests are disabled");
             }

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestPgpBatchRequest.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestPgpBatchRequest.cs
@@ -18,6 +18,11 @@ namespace Litle.Sdk.Test.Functional
         [TestFixtureSetUp]
         public void SetUp()
         {
+            var pgpEnabled = Environment.GetEnvironmentVariable("pgpFunctionalTestsEnabled");
+            if(pgpEnabled != null && pgpEnabled.ToLower.Equals("false"))
+            {
+                Assert.Ignore("PGP functional tests are disabled");
+            }
             _config = new Dictionary<string, string>();
             _config["url"] = Properties.Settings.Default.url;
             _config["reportGroup"] = Properties.Settings.Default.reportGroup;

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestPgpHelper.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestPgpHelper.cs
@@ -21,6 +21,11 @@ namespace Litle.Sdk.Test.Functional
         [TestFixtureSetUp]
         public void SetUp()
         {
+            var pgpEnabled = Environment.GetEnvironmentVariable("pgpFunctionalTestsEnabled");
+            if(pgpEnabled != null && pgpEnabled.ToLower.Equals("false"))
+            {
+                Assert.Ignore("PGP functional tests are disabled");
+            }
             _testDir = Path.Combine(Properties.Settings.Default.requestDirectory, "testPgp");
             if (!Directory.Exists(_testDir))
             {

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestPgpHelper.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestPgpHelper.cs
@@ -22,7 +22,7 @@ namespace Litle.Sdk.Test.Functional
         public void SetUp()
         {
             var pgpEnabled = Environment.GetEnvironmentVariable("pgpFunctionalTestsEnabled");
-            if(pgpEnabled != null && pgpEnabled.ToLower.Equals("false"))
+            if(pgpEnabled != null && pgpEnabled.ToLower().Equals("false"))
             {
                 Assert.Ignore("PGP functional tests are disabled");
             }

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestPhysicalCheck.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestPhysicalCheck.cs
@@ -40,7 +40,7 @@ namespace Litle.Sdk.Test.Functional
                 id = "1",
                 reportGroup = "Default Report Group",
                 // required child elements.
-                amount = 1500,
+                amount = 15121,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId"
             };
@@ -58,7 +58,7 @@ namespace Litle.Sdk.Test.Functional
                 id = "1",
                 reportGroup = "Planets",
                 // required child elements.
-                amount = 1500,
+                amount = 15121,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId"
             };

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestPhysicalCheck.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestPhysicalCheck.cs
@@ -40,7 +40,7 @@ namespace Litle.Sdk.Test.Functional
                 id = "1",
                 reportGroup = "Default Report Group",
                 // required child elements.
-                amount = 15121,
+                amount = 1000,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId"
             };

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestPhysicalCheck.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestPhysicalCheck.cs
@@ -58,7 +58,7 @@ namespace Litle.Sdk.Test.Functional
                 id = "1",
                 reportGroup = "Planets",
                 // required child elements.
-                amount = 15121,
+                amount = 1000,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId"
             };

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestReserve.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestReserve.cs
@@ -40,7 +40,7 @@ namespace Litle.Sdk.Test.Functional
                 id = "1",
                 reportGroup = "Default Report Group",
                 // required child elements.
-                amount = 1500,
+                amount = 15121,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId"
             };
@@ -58,7 +58,7 @@ namespace Litle.Sdk.Test.Functional
                 id = "1",
                 reportGroup = "Planets",
                 // required child elements.
-                amount = 1500,
+                amount = 15121,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId"
             };

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestReserve.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestReserve.cs
@@ -40,7 +40,7 @@ namespace Litle.Sdk.Test.Functional
                 id = "1",
                 reportGroup = "Default Report Group",
                 // required child elements.
-                amount = 15121,
+                amount = 1000,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId"
             };
@@ -58,7 +58,7 @@ namespace Litle.Sdk.Test.Functional
                 id = "1",
                 reportGroup = "Planets",
                 // required child elements.
-                amount = 15121,
+                amount = 1000,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId"
             };

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestSubmerchant.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestSubmerchant.cs
@@ -46,7 +46,7 @@ namespace Litle.Sdk.Test.Functional
                     accNum = "1234",
                     routingNum = "12345678"
                 },
-                amount = 15121,
+                amount = 1000,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId",
                 submerchantName = "Vantiv",
@@ -72,7 +72,7 @@ namespace Litle.Sdk.Test.Functional
                     accNum = "1234",
                     routingNum = "12345678"
                 },
-                amount = 15121,
+                amount = 1000,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId",
                 submerchantName = "Vantiv",

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestSubmerchant.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestSubmerchant.cs
@@ -46,7 +46,7 @@ namespace Litle.Sdk.Test.Functional
                     accNum = "1234",
                     routingNum = "12345678"
                 },
-                amount = 1500,
+                amount = 15121,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId",
                 submerchantName = "Vantiv",
@@ -72,7 +72,7 @@ namespace Litle.Sdk.Test.Functional
                     accNum = "1234",
                     routingNum = "12345678"
                 },
-                amount = 1500,
+                amount = 15121,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId",
                 submerchantName = "Vantiv",

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestVendor.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestVendor.cs
@@ -46,7 +46,7 @@ namespace Litle.Sdk.Test.Functional
                     accNum = "1234",
                     routingNum = "12345678"
                 },
-                amount = 1500,
+                amount = 15121,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId",
                 vendorName = "Vantiv"
@@ -71,7 +71,7 @@ namespace Litle.Sdk.Test.Functional
                     accNum = "1234",
                     routingNum = "12345678"
                 },
-                amount = 1500,
+                amount = 15121,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId",
                 vendorName = "WorldPay"

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestVendor.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestVendor.cs
@@ -46,7 +46,7 @@ namespace Litle.Sdk.Test.Functional
                     accNum = "1234",
                     routingNum = "12345678"
                 },
-                amount = 15121,
+                amount = 1000,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId",
                 vendorName = "Vantiv"
@@ -71,7 +71,7 @@ namespace Litle.Sdk.Test.Functional
                     accNum = "1234",
                     routingNum = "12345678"
                 },
-                amount = 15121,
+                amount = 1000,
                 fundingSubmerchantId = "value for fundingSubmerchantId",
                 fundsTransferId = "value for fundsTransferId",
                 vendorName = "WorldPay"


### PR DESCRIPTION
The goal of this change is to fix several functional tests that were failing due to a change in the responses from sandbox. 
This change also introduces the option to ignore PGP related tests.