### PR TITLE
Switch to OS agnostic directory separators

### DIFF
--- a/LitleSdkForNet/LitleSdkForNet/LitleBatch.cs
+++ b/LitleSdkForNet/LitleSdkForNet/LitleBatch.cs
@@ -93,8 +93,8 @@ namespace Litle.Sdk
             authentication.user = config["username"];
             authentication.password = config["password"];
 
-            requestDirectory = config["requestDirectory"] + "\\Requests\\";
-            responseDirectory = config["responseDirectory"] + "\\Responses\\";
+            requestDirectory = $"{config["requestDirectory"]}{Path.DirectorySeparatorChar}Requests{Path.DirectorySeparatorChar}";
+            responseDirectory = $"{config["responseDirectory"]}{Path.DirectorySeparatorChar}Responses{Path.DirectorySeparatorChar}";
 
             litleXmlSerializer = new litleXmlSerializer();
             litleTime = new litleTime();

--- a/LitleSdkForNet/LitleSdkForNet/LitleBatchRequest.cs
+++ b/LitleSdkForNet/LitleSdkForNet/LitleBatchRequest.cs
@@ -126,8 +126,8 @@ namespace Litle.Sdk
 
         private void initializeRequest()
         {
-            requestDirectory = config["requestDirectory"] + "\\Requests\\";
-            responseDirectory = config["responseDirectory"] + "\\Responses\\";
+            requestDirectory = $"{config["requestDirectory"]}{Path.DirectorySeparatorChar}Requests{Path.DirectorySeparatorChar}";
+            responseDirectory = $"{config["responseDirectory"]}{Path.DirectorySeparatorChar}Responses{Path.DirectorySeparatorChar}";
 
             litleFile = new litleFile();
             litleTime = new litleTime();
@@ -1487,8 +1487,8 @@ namespace Litle.Sdk
             litleTime = new litleTime();
             litleFile = new litleFile();
 
-            requestDirectory = config["requestDirectory"] + "\\Requests\\";
-            responseDirectory = config["responseDirectory"] + "\\Responses\\";
+            requestDirectory = $"{config["requestDirectory"]}{Path.DirectorySeparatorChar}Requests{Path.DirectorySeparatorChar}";
+            responseDirectory = $"{config["responseDirectory"]}{Path.DirectorySeparatorChar}Responses{Path.DirectorySeparatorChar}";
         }
 
         public RFRRequest(Dictionary<string, string> config)
@@ -1500,8 +1500,8 @@ namespace Litle.Sdk
 
         private void initializeRequest()
         {
-            requestDirectory = config["requestDirectory"] + "\\Requests\\";
-            responseDirectory = config["responseDirectory"] + "\\Responses\\";
+            requestDirectory = $"{config["requestDirectory"]}{Path.DirectorySeparatorChar}Requests{Path.DirectorySeparatorChar}";
+            responseDirectory = $"{config["responseDirectory"]}{Path.DirectorySeparatorChar}Responses{Path.DirectorySeparatorChar}";
 
             litleFile = new litleFile();
             litleTime = new litleTime();


### PR DESCRIPTION
Instead of hardcoding in the assumption that batch processing will be done on a windows machine this PR has been created to use `Path.DirectorySeparatorChar` to allow for operating system agnostic directory separator characters. 